### PR TITLE
Made framework and header search paths relative to project. Fixed typo

### DIFF
--- a/samples/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
+++ b/samples/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
@@ -136,7 +136,7 @@
 		81EE34341491452A00132035 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Orbotix, Inc.";
 				TargetAttributes = {
 					81EE343C1491452A00132035 = {
@@ -219,6 +219,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -282,12 +283,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"/Users/wes/Git/sdk/PUBLIC/Sphero-iOS-SDK/frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../frameworks";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "HelloWorld/HelloWorld-Prefix.pch";
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../frameworks";
 				INFOPLIST_FILE = "HelloWorld/HelloWorld-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
@@ -295,6 +294,7 @@
 					"-ObjC",
 					"-lc++",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.orbotix.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -304,12 +304,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"/Users/wes/Git/sdk/PUBLIC/Sphero-iOS-SDK/frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../frameworks";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "HelloWorld/HelloWorld-Prefix.pch";
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../frameworks";
 				INFOPLIST_FILE = "HelloWorld/HelloWorld-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
@@ -317,6 +315,7 @@
 					"-ObjC",
 					"-lc++",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.orbotix.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};

--- a/samples/HelloWorld/HelloWorld/HelloWorldViewController.m
+++ b/samples/HelloWorld/HelloWorld/HelloWorldViewController.m
@@ -95,7 +95,7 @@
 	if(!_robot || ![_robot isConnected]) return; // stop the toggle if no robot.
 
     if (_ledOn) {
-		[_robot setLEDWithRed:0 green:0 blue:0];
+		[_robot setLEDWithRed:1 green:0 blue:0];
     }
     else {
 		[_robot setLEDWithRed:0 green:0 blue:1];

--- a/samples/HelloWorld/HelloWorld/HelloWorldViewController.m
+++ b/samples/HelloWorld/HelloWorld/HelloWorldViewController.m
@@ -95,7 +95,7 @@
 	if(!_robot || ![_robot isConnected]) return; // stop the toggle if no robot.
 
     if (_ledOn) {
-		[_robot setLEDWithRed:1 green:0 blue:0];
+		[_robot setLEDWithRed:0 green:0 blue:0];
     }
     else {
 		[_robot setLEDWithRed:0 green:0 blue:1];

--- a/samples/SensorStreaming/SensorStreaming/ViewController.m
+++ b/samples/SensorStreaming/SensorStreaming/ViewController.m
@@ -117,7 +117,7 @@
 }
 
 - (void)handleConnected {
-    [_robot enableStablilization:NO];
+    [_robot enableStabilization:NO];
     [_robot addResponseObserver:self];
     [self sendSetDataStreamingCommand];
 }


### PR DESCRIPTION
In trying the iOS samples noticed a few small errors. Nice SDK overall!

HelloWorld Framework Search Path had absolute path: 
`/Users/wes/Git/sdk/PUBLIC/Sphero-iOS-SDK/frameworks`
changed to
`$(SRCROOT)/../../frameworks`

`SensorStreaming/ViewController.m` had typo in method name. (Note extra 'l')
`[_robot enableStablilization:NO];`
